### PR TITLE
Fix: Nimble file too strict for cross-compilation

### DIFF
--- a/ioselectors.nimble
+++ b/ioselectors.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.6"
+version       = "0.1.7"
 author        = "flywind"
 description   = "Selectors extension."
 license       = "Apache-2.0"
@@ -11,9 +11,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.2.6"
-
-when defined(windows):
-  requires "wepoll >= 0.1.0"
+requires "wepoll >= 0.1.0"
 
 requires "timerwheel >= 0.1.2"
 


### PR DESCRIPTION
Currently, I am working on a project I need to cross-compile to Windows.

https://github.com/xflywind/ioselectors/blob/228e80c168847e87b9965ff236a5fafa8a15a02b/ioselectors.nimble#L15-L16

This means, that when I install the dependency on Linux, I do not get the dependency, even though I need it in the end for cross-compilation.

As seen [here](https://github.com/xflywind/ioselectors/blob/228e80c168847e87b9965ff236a5fafa8a15a02b/src/ioselectors.nim), it also does not hurt, if the dependency is downloaded, even though you technically don't need it on Linux, after all.